### PR TITLE
Prefer MySQL utf8mb4 instead of utf8

### DIFF
--- a/doc/providers/doctrine.rst
+++ b/doc/providers/doctrine.rst
@@ -103,7 +103,7 @@ and values are options::
                 'dbname'    => 'my_database',
                 'user'      => 'my_username',
                 'password'  => 'my_password',
-                'charset'   => 'utf8',
+                'charset'   => 'utf8mb4',
             ),
             'mysql_write' => array(
                 'driver'    => 'pdo_mysql',
@@ -111,7 +111,7 @@ and values are options::
                 'dbname'    => 'my_database',
                 'user'      => 'my_username',
                 'password'  => 'my_password',
-                'charset'   => 'utf8',
+                'charset'   => 'utf8mb4',
             ),
         ),
     ));


### PR DESCRIPTION
MySQL's `utf8` character set is a little broken, and does not cover 4-byte UTF-8 characters. In most cases it will quietly truncate the string whenever it sees one, saving incomplete text data.  

In  5.5.3 they introduced `utf8mb4` to fix this inconsistency, and given that it's been 5 years, it's probably safe to encourage people to use it. If their MySQL installation is old, it should be easy for them to find the distinctive string and change it back to `utf8`.